### PR TITLE
docs: add template for pull requests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+# Descrição
+
+Inclua um resumo das alterações e qual problema foi corrigido. Inclua também motivação e/ou contextos relevantes. Liste todas as dependências necessárias para essa alteração.
+
+Fixes # (issue)
+
+## Tipo de mudança 🏗️
+
+_Exclua as opções que não são relevantes._
+
+Minha mudança é uma:
+
+- [ ] Correção de bug (alteração que corrige um problema)
+- [ ] Novo recurso (alteração que adiciona funcionalidades)
+- [ ] Esta alteração requer uma atualização de documentação
+
+## Como isso foi testado? 🧪
+
+Descreva os testes que você executou para verificar suas alterações.
+Forneça instruções para que possamos reproduzir.
+Liste também todos os detalhes relevantes para sua configuração de teste.
+
+## Checklist da PR ✅
+
+- [ ] Meu código segue as diretrizes de estilo deste projeto
+- [ ] Realizei uma autoavaliação do meu próprio código
+- [ ] Fiz alterações correspondentes na documentação
+- [ ] Minhas alterações não geram novos `warnings`
+- [ ] O título do meu PR está seguindo o padrão <type>(scope): subject.
+  - Exemplo 1 (com escopo): feat(page): add collaborators page
+  - Exemplo 2 (sem escopo): fix: prevent auto reload


### PR DESCRIPTION
# Descrição

Eaí, pessoal?

Nessa PR estou enviando um template de como abrir as PR's aqui pelo github adicionado na pasta `.github` um arquivo `.md`. Nesse template estou adicionando algumas coisas comumente usadas em alguns repositório abertos e com base em algumas pesquisas feitas.

## Tipo de mudança 🏗️

Minha mudança é uma:

- [x] Novo recurso (alteração que adiciona funcionalidades)

## Como isso foi testado? 🧪

Antes para enviar um PR tínhamos um espaço em branco para envio e descrição livre, agora teremos um template pronto assim que iniciamos uma criação de Pull Request como na imagem abaixo:

![image](https://user-images.githubusercontent.com/71537090/232946216-d455709b-e389-4a08-bc9d-78adaa019c8c.png)

## Checklist da PR ✅

- [x] Meu código segue as diretrizes de estilo deste projeto
- [x] Realizei uma autoavaliação do meu próprio código
- [x] Fiz alterações correspondentes na documentação
- [x] Minhas alterações não geram novos `warnings`
- [x] O título do meu PR está seguindo o padrão <type>(scope): subject.
  - Exemplo 1 (com escopo): feat(page): add collaborators page
  - Exemplo 2 (sem escopo): fix: prevent auto reload
