### PR TITLE
ci(workflows): add workflow to check types and lint with project scripts

### DIFF
--- a/.github/workflows/ci-linting.yml
+++ b/.github/workflows/ci-linting.yml
@@ -1,0 +1,45 @@
+name: CI - Linting
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - '**'
+
+jobs:
+  lint:
+    name: Linting ✨
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+
+      - name: Clean install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Lint
+        run: npm run lint
+
+  types:
+    name: Types Checking 🔎
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+
+      - name: Clean install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Types check
+        run: npm run types:check

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "lint": "eslint src --ext .ts --fix",
+    "lint": "eslint --ext .ts,.tsx . --no-error-on-unmatched-pattern",
+    "lint:fix": "eslint --ext .ts,.tsx . --no-error-on-unmatched-pattern --fix",
+    "types:check": "tsc --noEmit --pretty",
     "prepare": "husky install"
   },
   "dependencies": {


### PR DESCRIPTION
# Descrição

Essa pull request visa resolver a atividade #2 para adição de um job que verifica se há problemas no estilo do código ou na declaração de tipos do typescript.

Fixes #2

## Tipo de mudança 🏗️

Minha mudança é uma:

- [x] Novo recurso (alteração que adiciona funcionalidades)

## Como isso foi testado? 🧪

Antes eu poderia enviar um código fora do padrão como no exemplo:

```tsx
import { Maintenance } from "./pages/Maintenance"

export function App() {
  return <Maintenance />
}
```

que era aceito sem problemas nenhuma.

> ⚠️ O problema do código acima é o uso de aspas duplas, embora não ocasione nenhum erro, foge ao padrão usado no projeto.

Após adicionar os scripts de linting é possível acompanhar seu funcionamento pelo terminal onde executando o comando `npm run lint` temos o seguinte erro:

![image](https://user-images.githubusercontent.com/71537090/234161517-704168c6-8239-49d2-b184-43d9cfb1d88c.png)

Tais scripts são usados nos `workflows` do github e pode ser visto na aba actions do repositório.

Após a adição dos scripts e do workflow as PR's e Push's terão uma verificação dos tipos e estilo de escrita de código.

## Checklist da PR ✅

- [x] Meu código segue as diretrizes de estilo deste projeto
- [x] Realizei uma autoavaliação do meu próprio código
- [x] Minhas alterações não geram novos `warnings`
- [x] O título do meu PR está seguindo o padrão <type>(scope): subject.
  - Exemplo 1 (com escopo): feat(page): add collaborators page
  - Exemplo 2 (sem escopo): fix: prevent auto reload
